### PR TITLE
tweaked pokemon locations/stats for personal play preferences

### DIFF
--- a/data/moves/moves.asm
+++ b/data/moves/moves.asm
@@ -18,7 +18,7 @@ Moves:
 	move KARATE_CHOP,  EFFECT_NORMAL_HIT,         50, FIGHTING,     100, 25,   0
 	move DOUBLESLAP,   EFFECT_MULTI_HIT,          15, NORMAL,        85, 10,   0
 	move COMET_PUNCH,  EFFECT_MULTI_HIT,          18, NORMAL,        85, 15,   0
-	move MEGA_PUNCH,   EFFECT_NORMAL_HIT,         80, NORMAL,        85, 20,   0
+	move MEGA_PUNCH,   EFFECT_NORMAL_HIT,         80, FIGHTING,      85, 20,   0
 	move PAY_DAY,      EFFECT_PAY_DAY,            40, NORMAL,       100, 20,   0
 	move FIRE_PUNCH,   EFFECT_BURN_HIT,           75, FIRE,         100, 15,  10
 	move ICE_PUNCH,    EFFECT_FREEZE_HIT,         75, ICE,          100, 15,  10
@@ -28,7 +28,7 @@ Moves:
 	move GUILLOTINE,   EFFECT_OHKO,                0, NORMAL,        30,  5,   0
 	move RAZOR_WIND,   EFFECT_RAZOR_WIND,         80, NORMAL,        75, 10,   0
 	move SWORDS_DANCE, EFFECT_ATTACK_UP_2,         0, NORMAL,       100, 30,   0
-	move CUT,          EFFECT_NORMAL_HIT,         50, NORMAL,        95, 30,   0
+	move CUT,          EFFECT_NORMAL_HIT,         90, GRASS,         95, 30,   0
 	move GUST,         EFFECT_GUST,               40, FLYING,       100, 35,   0
 	move WING_ATTACK,  EFFECT_NORMAL_HIT,         60, FLYING,       100, 35,   0
 	move WHIRLWIND,    EFFECT_FORCE_SWITCH,        0, NORMAL,       100, 20,   0
@@ -38,7 +38,7 @@ Moves:
 	move VINE_WHIP,    EFFECT_NORMAL_HIT,         35, GRASS,        100, 10,   0
 	move STOMP,        EFFECT_STOMP,              65, NORMAL,       100, 20,  30
 	move DOUBLE_KICK,  EFFECT_DOUBLE_HIT,         30, FIGHTING,     100, 30,   0
-	move MEGA_KICK,    EFFECT_NORMAL_HIT,        120, NORMAL,        75,  5,   0
+	move MEGA_KICK,    EFFECT_NORMAL_HIT,        120, FIGHTING,      75,  5,   0
 	move JUMP_KICK,    EFFECT_JUMP_KICK,          70, FIGHTING,      95, 25,   0
 	move ROLLING_KICK, EFFECT_FLINCH_HIT,         60, FIGHTING,      85, 15,  30
 	move SAND_ATTACK,  EFFECT_ACCURACY_DOWN,       0, GROUND,       100, 15,   0
@@ -159,9 +159,9 @@ Moves:
 	move SKY_ATTACK,   EFFECT_SKY_ATTACK,        140, FLYING,        90,  5,   0
 	move TRANSFORM,    EFFECT_TRANSFORM,           0, NORMAL,       100, 10,   0
 	move BUBBLE,       EFFECT_SPEED_DOWN_HIT,     20, WATER,        100, 30,  10
-	move DIZZY_PUNCH,  EFFECT_CONFUSE_HIT,        70, NORMAL,       100, 10,  20
+	move DIZZY_PUNCH,  EFFECT_CONFUSE_HIT,        70, FIGHTING,     100, 10,  20
 	move SPORE,        EFFECT_SLEEP,               0, GRASS,        100, 15,   0
-	move FLASH,        EFFECT_ACCURACY_DOWN,       0, NORMAL,        70, 20,   0
+	move FLASH,        EFFECT_ACCURACY_DOWN,      90, ELECTRIC,      95, 20,   0
 	move PSYWAVE,      EFFECT_PSYWAVE,             1, PSYCHIC_TYPE,  80, 15,   0
 	move SPLASH,       EFFECT_SPLASH,              0, NORMAL,       100, 40,   0
 	move ACID_ARMOR,   EFFECT_DEFENSE_UP_2,        0, POISON,       100, 40,   0

--- a/data/pokemon/base_stats/abra.asm
+++ b/data/pokemon/base_stats/abra.asm
@@ -1,10 +1,12 @@
 	db ABRA ; 063
 
-	db  25,  20,  15,  90, 105,  55
+	;original stats
+	;db  25,  20,  15,  90, 105,  55
+	db  40,  30,  25,  95, 105,  55
 	;   hp  atk  def  spd  sat  sdf
 
 	db PSYCHIC_TYPE, PSYCHIC_TYPE ; type
-	db 200 ; catch rate
+	db 255 ; catch rate
 	db 73 ; base exp
 	db NO_ITEM, NO_ITEM ; items
 	db GENDER_F25 ; gender ratio

--- a/data/pokemon/base_stats/alakazam.asm
+++ b/data/pokemon/base_stats/alakazam.asm
@@ -1,6 +1,8 @@
 	db ALAKAZAM ; 065
 
-	db  55,  50,  45, 120, 135,  85
+	;original stats
+	;db  55,  50,  45, 120, 135,  85
+	db  80,  75,  70, 125, 135,  85
 	;   hp  atk  def  spd  sat  sdf
 
 	db PSYCHIC_TYPE, PSYCHIC_TYPE ; type

--- a/data/pokemon/base_stats/dodrio.asm
+++ b/data/pokemon/base_stats/dodrio.asm
@@ -1,6 +1,8 @@
 	db DODRIO ; 085
 
-	db  60, 110,  70, 100,  60,  60
+	;original stats
+	;db  60, 110,  70, 100,  60,  60
+	db  75, 115,  85, 120,  70,  80
 	;   hp  atk  def  spd  sat  sdf
 
 	db NORMAL, FLYING ; type

--- a/data/pokemon/base_stats/doduo.asm
+++ b/data/pokemon/base_stats/doduo.asm
@@ -1,10 +1,12 @@
 	db DODUO ; 084
 
-	db  35,  85,  45,  75,  35,  35
+	;original stats
+	;db  35,  85,  45,  75,  35,  35
+	db  45,  90,  55,  90,  45,  50
 	;   hp  atk  def  spd  sat  sdf
 
 	db NORMAL, FLYING ; type
-	db 190 ; catch rate
+	db 255 ; catch rate
 	db 96 ; base exp
 	db NO_ITEM, NO_ITEM ; items
 	db GENDER_F50 ; gender ratio

--- a/data/pokemon/base_stats/heracross.asm
+++ b/data/pokemon/base_stats/heracross.asm
@@ -1,10 +1,12 @@
 	db HERACROSS ; 214
 
-	db  80, 125,  75,  85,  40,  95
+	;original stats
+	;db  80, 125,  75,  85,  40,  95
+	db  80, 125,  75,  95, 100, 100
 	;   hp  atk  def  spd  sat  sdf
 
 	db BUG, FIGHTING ; type
-	db 45 ; catch rate
+	db 255 ; catch rate
 	db 200 ; base exp
 	db NO_ITEM, NO_ITEM ; items
 	db GENDER_F50 ; gender ratio

--- a/data/pokemon/base_stats/kadabra.asm
+++ b/data/pokemon/base_stats/kadabra.asm
@@ -1,6 +1,8 @@
 	db KADABRA ; 064
 
-	db  40,  35,  30, 105, 120,  70
+	;original stats
+	;db  40,  35,  30, 105, 120,  70
+	db  60,  55,  50, 110, 120,  70
 	;   hp  atk  def  spd  sat  sdf
 
 	db PSYCHIC_TYPE, PSYCHIC_TYPE ; type

--- a/data/pokemon/base_stats/mantine.asm
+++ b/data/pokemon/base_stats/mantine.asm
@@ -1,10 +1,12 @@
 	db MANTINE ; 226
 
-	db  65,  40,  70,  70,  80, 140
+	;original stats
+	;db  65,  40,  70,  70,  80, 140
+	db  90, 100,  70,  80,  80, 140
 	;   hp  atk  def  spd  sat  sdf
 
 	db WATER, FLYING ; type
-	db 25 ; catch rate
+	db 255 ; catch rate
 	db 168 ; base exp
 	db NO_ITEM, NO_ITEM ; items
 	db GENDER_F50 ; gender ratio

--- a/data/pokemon/base_stats/onix.asm
+++ b/data/pokemon/base_stats/onix.asm
@@ -1,10 +1,12 @@
 	db ONIX ; 095
 
-	db  35,  45, 160,  70,  30,  45
+	;original stats
+	;db  35,  45, 160,  70,  30,  45
+	db  40,  50, 150,  70,  50,  70
 	;   hp  atk  def  spd  sat  sdf
 
 	db ROCK, GROUND ; type
-	db 45 ; catch rate
+	db 255 ; catch rate
 	db 108 ; base exp
 	db NO_ITEM, NO_ITEM ; items
 	db GENDER_F50 ; gender ratio

--- a/data/pokemon/base_stats/steelix.asm
+++ b/data/pokemon/base_stats/steelix.asm
@@ -1,6 +1,8 @@
 	db STEELIX ; 208
 
-	db  75,  85, 200,  30,  55,  65
+	;original stats
+	;db  75,  85, 200,  30,  55,  65
+	db  85,  95, 180,  60, 75,  100
 	;   hp  atk  def  spd  sat  sdf
 
 	db STEEL, GROUND ; type

--- a/data/pokemon/evos_attacks.asm
+++ b/data/pokemon/evos_attacks.asm
@@ -803,7 +803,7 @@ PoliwagEvosAttacks:
 
 PoliwhirlEvosAttacks:
 	db EVOLVE_ITEM, WATER_STONE, POLIWRATH
-	db EVOLVE_TRADE, KINGS_ROCK, POLITOED
+	db EVOLVE_ITEM, MOON_STONE,  POLITOED
 	db 0 ; no more evolutions
 	db 1, BUBBLE
 	db 1, HYPNOSIS
@@ -831,18 +831,21 @@ AbraEvosAttacks:
 	db EVOLVE_LEVEL, 16, KADABRA
 	db 0 ; no more evolutions
 	db 1, TELEPORT
+	db 5, TACKLE
+	db 11, CONFUSION
 	db 0 ; no more level-up moves
 
 KadabraEvosAttacks:
-	db EVOLVE_TRADE, -1, ALAKAZAM
+	db EVOLVE_LEVEL, 36, ALAKAZAM
+	db EVOLVE_ITEM, MOON_STONE, ALAKAZAM
 	db 0 ; no more evolutions
 	db 1, TELEPORT
 	db 1, KINESIS
 	db 1, CONFUSION
-	db 16, CONFUSION
 	db 18, DISABLE
 	db 21, PSYBEAM
 	db 26, RECOVER
+	db 28, THUNDERPUNCH
 	db 31, FUTURE_SIGHT
 	db 38, PSYCHIC_M
 	db 45, REFLECT
@@ -857,6 +860,7 @@ AlakazamEvosAttacks:
 	db 18, DISABLE
 	db 21, PSYBEAM
 	db 26, RECOVER
+	db 28, THUNDERPUNCH
 	db 31, FUTURE_SIGHT
 	db 38, PSYCHIC_M
 	db 45, REFLECT
@@ -878,7 +882,7 @@ MachopEvosAttacks:
 	db 0 ; no more level-up moves
 
 MachokeEvosAttacks:
-	db EVOLVE_TRADE, -1, MACHAMP
+	db EVOLVE_ITEM, SUN_STONE, MACHAMP
 	db 0 ; no more evolutions
 	db 1, LOW_KICK
 	db 1, LEER
@@ -992,7 +996,7 @@ GeodudeEvosAttacks:
 	db 0 ; no more level-up moves
 
 GravelerEvosAttacks:
-	db EVOLVE_TRADE, -1, GOLEM
+	db EVOLVE_ITEM, SUN_STONE,  GOLEM
 	db 0 ; no more evolutions
 	db 1, TACKLE
 	db 1, DEFENSE_CURL
@@ -1056,7 +1060,7 @@ RapidashEvosAttacks:
 
 SlowpokeEvosAttacks:
 	db EVOLVE_LEVEL, 37, SLOWBRO
-	db EVOLVE_TRADE, KINGS_ROCK, SLOWKING
+	db EVOLVE_ITEM, WATER_STONE, SLOWKING
 	db 0 ; no more evolutions
 	db 1, CURSE
 	db 1, TACKLE
@@ -1151,6 +1155,7 @@ DodrioEvosAttacks:
 	db 21, TRI_ATTACK
 	db 25, RAGE
 	db 38, DRILL_PECK
+	db 42, SKY_ATTACK
 	db 47, AGILITY
 	db 0 ; no more level-up moves
 
@@ -1199,12 +1204,12 @@ MukEvosAttacks:
 	db 1, POISON_GAS
 	db 1, POUND
 	db 1, HARDEN
+	db 23, MINIMIZE
+	db 31, SCREECH
 	db 33, HARDEN
 	db 37, DISABLE
 	db 45, SLUDGE
-	db 23, MINIMIZE
-	db 31, SCREECH
-	db 45, ACID_ARMOR
+	db 46, ACID_ARMOR
 	db 60, SLUDGE_BOMB
 	db 0 ; no more level-up moves
 
@@ -1246,7 +1251,7 @@ GastlyEvosAttacks:
 	db 0 ; no more level-up moves
 
 HaunterEvosAttacks:
-	db EVOLVE_TRADE, -1, GENGAR
+	db EVOLVE_ITEM, MOON_STONE, GENGAR
 	db 0 ; no more evolutions
 	db 1, HYPNOSIS
 	db 1, LICK
@@ -1275,16 +1280,23 @@ GengarEvosAttacks:
 	db 0 ; no more level-up moves
 
 OnixEvosAttacks:
-	db EVOLVE_TRADE, METAL_COAT, STEELIX
+	db EVOLVE_LEVEL, 25, STEELIX
+	db EVOLVE_ITEM, SUN_STONE,  STEELIX
 	db 0 ; no more evolutions
 	db 1, TACKLE
 	db 1, SCREECH
+	db 5, BITE
 	db 10, BIND
 	db 14, ROCK_THROW
 	db 23, HARDEN
 	db 27, RAGE
+	db 30, ROCK_SLIDE
+	db 32, DIG
 	db 36, SANDSTORM
 	db 40, SLAM
+	db 45, EARTHQUAKE
+	db 49, CRUNCH
+	db 60, HYPER_BEAM
 	db 0 ; no more level-up moves
 
 DrowzeeEvosAttacks:
@@ -1585,7 +1597,7 @@ HorseaEvosAttacks:
 	db 0 ; no more level-up moves
 
 SeadraEvosAttacks:
-	db EVOLVE_TRADE, DRAGON_SCALE, KINGDRA
+	db EVOLVE_ITEM, WATER_STONE,  KINGDRA
 	db 0 ; no more evolutions
 	db 1, BUBBLE
 	db 1, SMOKESCREEN
@@ -1667,7 +1679,7 @@ MrMimeEvosAttacks:
 	db 0 ; no more level-up moves
 
 ScytherEvosAttacks:
-	db EVOLVE_TRADE, METAL_COAT, SCIZOR
+	db EVOLVE_ITEM, LEAF_STONE,  SCIZOR
 	db 0 ; no more evolutions
 	db 1, QUICK_ATTACK
 	db 1, LEER
@@ -1805,6 +1817,7 @@ EeveeEvosAttacks:
 	db 23, QUICK_ATTACK
 	db 30, BITE
 	db 36, BATON_PASS
+	db 38, FOCUS_ENERGY
 	db 42, TAKE_DOWN
 	db 0 ; no more level-up moves
 
@@ -1851,7 +1864,7 @@ FlareonEvosAttacks:
 	db 0 ; no more level-up moves
 
 PorygonEvosAttacks:
-	db EVOLVE_TRADE, UP_GRADE, PORYGON2
+	db EVOLVE_ITEM, THUNDERSTONE,  PORYGON2
 	db 0 ; no more evolutions
 	db 1, CONVERSION2
 	db 1, TACKLE
@@ -1986,10 +1999,11 @@ DratiniEvosAttacks:
 	db 0 ; no more evolutions
 	db 1, WRAP
 	db 1, LEER
-	db 8, THUNDER_WAVE
+	db 8, THUNDERSHOCK
 	db 15, TWISTER
 	db 22, DRAGON_RAGE
 	db 29, SLAM
+	db 32, THUNDERBOLT
 	db 36, AGILITY
 	db 43, SAFEGUARD
 	db 50, OUTRAGE
@@ -2003,11 +2017,13 @@ DragonairEvosAttacks:
 	db 1, LEER
 	db 1, THUNDER_WAVE
 	db 1, TWISTER
-	db 8, THUNDER_WAVE
+	db 8, THUNDERSHOCK
 	db 15, TWISTER
 	db 22, DRAGON_RAGE
 	db 29, SLAM
+	db 32, THUNDERBOLT
 	db 38, AGILITY
+	db 42, ICE_BEAM
 	db 47, SAFEGUARD
 	db 56, OUTRAGE
 	db 65, HYPER_BEAM
@@ -2019,11 +2035,13 @@ DragoniteEvosAttacks:
 	db 1, LEER
 	db 1, THUNDER_WAVE
 	db 1, TWISTER
-	db 8, THUNDER_WAVE
+	db 8, THUNDERSHOCK
 	db 15, TWISTER
 	db 22, DRAGON_RAGE
 	db 29, SLAM
+	db 32, THUNDERBOLT
 	db 38, AGILITY
+	db 42, ICE_BEAM
 	db 47, SAFEGUARD
 	db 55, WING_ATTACK
 	db 61, OUTRAGE
@@ -2126,8 +2144,11 @@ QuilavaEvosAttacks:
 	db 12, EMBER
 	db 21, QUICK_ATTACK
 	db 31, FLAME_WHEEL
+	db 37, FIRE_PUNCH
 	db 42, SWIFT
+	db 48, EARTHQUAKE
 	db 54, FLAMETHROWER
+	db 66, FIRE_BLAST
 	db 0 ; no more level-up moves
 
 TyphlosionEvosAttacks:
@@ -2140,8 +2161,11 @@ TyphlosionEvosAttacks:
 	db 12, EMBER
 	db 21, QUICK_ATTACK
 	db 31, FLAME_WHEEL
+	db 39, FIRE_PUNCH
 	db 45, SWIFT
+	db 52, EARTHQUAKE
 	db 60, FLAMETHROWER
+	db 75, FIRE_BLAST
 	db 0 ; no more level-up moves
 
 TotodileEvosAttacks:
@@ -2785,13 +2809,19 @@ SteelixEvosAttacks:
 	db 0 ; no more evolutions
 	db 1, TACKLE
 	db 1, SCREECH
+	db 5, BITE
 	db 10, BIND
 	db 14, ROCK_THROW
 	db 23, HARDEN
+	db 25, IRON_TAIL
 	db 27, RAGE
+	db 30, ROCK_SLIDE
+	db 32, DIG
 	db 36, SANDSTORM
 	db 40, SLAM
+	db 45, EARTHQUAKE
 	db 49, CRUNCH
+	db 60, HYPER_BEAM
 	db 0 ; no more level-up moves
 
 SnubbullEvosAttacks:
@@ -2865,10 +2895,14 @@ HeracrossEvosAttacks:
 	db 1, LEER
 	db 6, HORN_ATTACK
 	db 12, ENDURE
+	db 15, HEADBUTT
 	db 19, FURY_ATTACK
+	db 23, LEECH_LIFE
 	db 27, COUNTER
 	db 35, TAKE_DOWN
+	db 38, MEGA_PUNCH
 	db 44, REVERSAL
+	db 46, MEGA_KICK
 	db 54, MEGAHORN
 	db 0 ; no more level-up moves
 
@@ -3019,7 +3053,9 @@ MantineEvosAttacks:
 	db 18, BUBBLEBEAM
 	db 25, TAKE_DOWN
 	db 32, AGILITY
+	db 37, ICE_BEAM
 	db 40, WING_ATTACK
+	db 45, HYDRO_PUMP
 	db 49, CONFUSE_RAY
 	db 0 ; no more level-up moves
 
@@ -3317,9 +3353,9 @@ TyranitarEvosAttacks:
 
 LugiaEvosAttacks:
 	db 0 ; no more evolutions
-	db 1, AEROBLAST
+	db 1,  GUST
 	db 11, SAFEGUARD
-	db 22, GUST
+	db 22, AEROBLAST ;GUST
 	db 33, RECOVER
 	db 44, HYDRO_PUMP
 	db 55, RAIN_DANCE
@@ -3331,9 +3367,9 @@ LugiaEvosAttacks:
 
 HoOhEvosAttacks:
 	db 0 ; no more evolutions
-	db 1, SACRED_FIRE
+	db 1,  GUST
 	db 11, SAFEGUARD
-	db 22, GUST
+	db 22, SACRED_FIRE ;GUST
 	db 33, RECOVER
 	db 44, FIRE_BLAST
 	db 55, SUNNY_DAY

--- a/data/wild/johto_grass.asm
+++ b/data/wild/johto_grass.asm
@@ -1657,29 +1657,29 @@ JohtoGrassWildMons:
 	def_grass_wildmons ROUTE_46
 	db 10 percent, 10 percent, 10 percent ; encounter rates: morn/day/nite
 	; morn
-	db 2, GEODUDE
-	db 2, SPEAROW
-	db 3, GEODUDE
-	db 3, RATTATA
-	db 2, PHANPY
-	db 2, RATTATA
-	db 2, RATTATA
+	db 5, ABRA
+	db 5, LARVITAR
+	db 5, ONIX
+	db 5, DODUO
+	db 5, GASTLY
+	db 5, MANTINE
+	db 5, PHANPY
 	; day
-	db 2, GEODUDE
-	db 2, SPEAROW
-	db 3, GEODUDE
-	db 3, RATTATA
-	db 2, RATTATA
-	db 2, RATTATA
-	db 2, RATTATA
+	db 5, ABRA
+	db 5, LARVITAR
+	db 5, ONIX
+	db 5, DODUO
+	db 5, GEODUDE
+	db 5, MANTINE
+	db 5, PHANPY
 	; nite
-	db 2, GEODUDE
-	db 2, RATTATA
-	db 3, GEODUDE
-	db 3, RATTATA
-	db 2, RATTATA
-	db 2, RATTATA
-	db 2, RATTATA
+	db 5, ABRA
+	db 5, LARVITAR
+	db 5, ONIX
+	db 5, DODUO
+	db 5, GASTLY
+	db 5, MANTINE
+	db 5, PHANPY
 	end_grass_wildmons
 
 	def_grass_wildmons SILVER_CAVE_OUTSIDE

--- a/data/wild/probabilities.asm
+++ b/data/wild/probabilities.asm
@@ -5,18 +5,18 @@ ENDM
 
 GrassMonProbTable:
 	table_width 2, GrassMonProbTable
-	mon_prob 30,  0 ; 30% chance
-	mon_prob 60,  1 ; 30% chance
-	mon_prob 80,  2 ; 20% chance
-	mon_prob 90,  3 ; 10% chance
-	mon_prob 95,  4 ;  5% chance
-	mon_prob 99,  5 ;  4% chance
-	mon_prob 100, 6 ;  1% chance
+	mon_prob 25,  0 ; 25% chance
+	mon_prob 50,  1 ; 25% chance
+	mon_prob 70,  2 ; 20% chance
+	mon_prob 80,  3 ; 10% chance
+	mon_prob 90,  4 ; 10% chance
+	mon_prob 95,  5 ;  5% chance
+	mon_prob 100, 6 ;  5% chance
 	assert_table_length NUM_GRASSMON
 
 WaterMonProbTable:
 	table_width 2, WaterMonProbTable
-	mon_prob 60,  0 ; 60% chance
-	mon_prob 90,  1 ; 30% chance
-	mon_prob 100, 2 ; 10% chance
+	mon_prob 45,  0 ; 45% chance
+	mon_prob 75,  1 ; 30% chance
+	mon_prob 100, 2 ; 25% chance
 	assert_table_length NUM_WATERMON


### PR DESCRIPTION
Added Abra, Larvitar, Onix, Doduo, Gastly(N,M), Geodude(D), Mantine, Phanpy to route 46 and made all level 5 ("C:\cygwin64\home\Serve\pokecrystal-edit\data\wild\johto_grass.asm")
changed probability rates now (25, 25, 20, 10, 10, 5, 5 % for grass, and 45, 30, 25% for water) ("C:\cygwin64\home\Serve\pokecrystal-edit\data\wild\probabilities.asm")
Adjusted moves for Abra evos, Typhlosion, Onix, Steelix, Dodrio, Mantine, Heracross, Ho-oh and Lugia ("C:\cygwin64\home\Serve\pokecrystal-edit\data\pokemon\evos_attacks.asm")
Adjusted stats for Abra evos, Onix, Steelix, Doduo/Dodrio, Mantine, Heracross ()
Pokemon that normally evolve with trades, evolve through the use of stones. Kadabra also evolves at level 36 and Onix evolves at level 32
Made Mega Punch/Kick fighting moves, Made Flash useful in battle (electric type, 90 damage, 95%), Made Cut useful in battle (grass type, 90 damage, 95%) ("C:\cygwin64\home\Serve\pokecrystal-edit\data\moves\moves.asm")